### PR TITLE
Replace pybel by openbabel.pybel

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,7 +5,7 @@ import_heading_stdlib=Core Library modules
 import_heading_thirdparty=Third party modules
 import_heading_firstparty=First party modules
 import_heading_localfolder=Local modules
-known_third_party = numpy,pybel,rdkit,recommonmark,scipy,setuptools
+known_third_party = numpy,openbabel,rdkit,recommonmark,scipy,setuptools
 
 multi_line_output=3
 include_trailing_comma=True

--- a/PyBioMed/PyGetMol/Getmol.py
+++ b/PyBioMed/PyGetMol/Getmol.py
@@ -105,7 +105,7 @@ def ReadMolFromInchi(inchi=""):
         Output: res is a molecule object.
     #################################################################
     """
-    import pybel
+    from openbabel import pybel
 
     temp = pybel.readstring("inchi", inchi)
     smi = temp.write("smi")
@@ -140,7 +140,7 @@ def GetMolFromCAS(casid=""):
     Downloading the molecules from http://www.chemnet.com/cas/ by CAS ID (casid).
     if you want to use this function, you must be install pybel.
     """
-    import pybel
+    from openbabel import pybel
 
     casid = string.strip(casid)
     localfile = urlopen(

--- a/PyBioMed/PyMolecule/fingerprint.py
+++ b/PyBioMed/PyMolecule/fingerprint.py
@@ -20,7 +20,7 @@ Email: gadsby@163.com and oriental-cds@163.com
 ##############################################################################
 """
 # Third party modules
-import pybel
+from openbabel import pybel
 from rdkit import Chem, DataStructs
 from rdkit.Chem import AllChem, ChemicalFeatures, MACCSkeys
 from rdkit.Chem.AtomPairs import Pairs, Torsions

--- a/PyBioMed/PyProtein/AAIndex.py
+++ b/PyBioMed/PyProtein/AAIndex.py
@@ -20,6 +20,8 @@ Email: gadsby@163.com
 
 """
 
+from __future__ import print_function
+
 # Core Library modules
 import os
 import string

--- a/PyBioMed/Pymolecule.py
+++ b/PyBioMed/Pymolecule.py
@@ -141,7 +141,7 @@ class PyMolecule:
             Output: res is a molecule object.
         #################################################################
         """
-        import pybel
+        from openbabel import pybel
 
         temp = pybel.readstring("inchi", inchi)
         smi = temp.write("smi")

--- a/PyBioMed/doc/User_guide.rst
+++ b/PyBioMed/doc/User_guide.rst
@@ -296,7 +296,7 @@ Calculating fingerprint via functions
 The :func:`CalculateFP2Fingerprint` function calculates the FP2 fingerprint.
 
 >>> from PyBioMed.PyMolecule.fingerprint import CalculateFP2Fingerprint
->>> import pybel
+>>> from openbabel import pybel
 >>> smi = 'CCC1(c2ccccc2)C(=O)N(C)C(=N1)O'
 >>> mol = pybel.readstring("smi", smi)
 >>> mol_fingerprint = CalculateFP2Fingerprint(mol)

--- a/PyBioMed/test/test_PyMolecule.py
+++ b/PyBioMed/test/test_PyMolecule.py
@@ -21,7 +21,7 @@ import os
 def test_pymolecule():
 
     from rdkit import Chem
-    import pybel
+    from openbabel import pybel
     from PyBioMed.PyMolecule.AtomProperty import (
         AtomProperty,
         GetAbsoluteAtomicProperty,

--- a/conda-env-27.yml
+++ b/conda-env-27.yml
@@ -1,0 +1,10 @@
+name: py27
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=2.7.17
+  - openbabel=3.0.0
+  - scipy=1.2.1
+  - pytest=4.6.2
+  - rdkit=2018.09.3

--- a/conda-env-38.yml
+++ b/conda-env-38.yml
@@ -1,0 +1,10 @@
+name: py38
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.8.1
+  - openbabel=3.0.0
+  - scipy=1.4.1
+  - pytest=5.4.1
+  - rdkit=2019.09.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,6 @@ classifiers =
 [options]
 zip_safe = false
 packages = find:
+
+[tool:pytest]
+norecursedirs = PyBioMed/doc/_build/*


### PR DESCRIPTION
Fixes some small bugs I accidentally introduced. Now the Python 2.7 tests run again and some more tests run for Python 3.8