### PR TITLE
Fixes for errors in computation of All descriptors and addition of the remaining descriptors from ChemoPy

### DIFF
--- a/PyBioMed/PyMolecule/estate.py
+++ b/PyBioMed/PyMolecule/estate.py
@@ -69,6 +69,28 @@ def _CalculateEState(mol, skipH=1):
     res = accum + Is
     return res
 
+def _CalculateAtomEState(mol,AtomicNum=6):
+    """
+    #################################################################
+    **Internal used only**
+    
+    The sum of the EState indices over all atoms 
+    #################################################################
+    """
+    nAtoms=mol.GetNumAtoms()
+    Is=numpy.zeros(nAtoms,numpy.float)
+    Estate=_CalculateEState(mol)
+    
+    for i in range(nAtoms):
+        at=mol.GetAtomWithIdx(i)
+        atNum=at.GetAtomicNum()
+        if atNum==AtomicNum:
+            Is[i]=Estate[i]
+            
+    res=sum(Is)
+    
+    return res
+
 
 def _GetPrincipleQuantumNumber(atNum):
     """
@@ -174,6 +196,112 @@ def CalculateMaxAtomTypeEState(mol):
 
     return ESresult
 
+def CalculateHeavyAtomEState(mol):
+    
+    """
+    #################################################################
+    The sum of the EState indices over all non-hydrogen atoms
+    
+    -->Shev
+    #################################################################
+    """
+    
+    return round(sum(_CalculateEState(mol)),3)
+
+def CalculateCAtomEState(mol):
+    """
+    #################################################################
+    The sum of the EState indices over all C atoms
+    
+    -->Scar
+    #################################################################
+    """
+    return _CalculateAtomEState(mol,AtomicNum=6)
+
+
+
+def CalculateHalogenEState(mol):
+    
+    """
+    #################################################################
+    The sum of the EState indices over all Halogen atoms
+    
+    -->Shal
+    #################################################################
+    """
+    
+    Nf=_CalculateAtomEState(mol,AtomicNum=9)
+    Ncl=_CalculateAtomEState(mol,AtomicNum=17)
+    Nbr=_CalculateAtomEState(mol,AtomicNum=35)
+    Ni=_CalculateAtomEState(mol,AtomicNum=53)
+  
+    return round(Nf+Ncl+Nbr+Ni,3)
+
+
+
+def CalculateHeteroEState(mol):
+    """
+    #################################################################
+    The sum of the EState indices over all hetero atoms
+    
+    -->Shet
+    #################################################################
+    """
+    
+    Ntotal=sum(_CalculateEState(mol))
+    NC=_CalculateAtomEState(mol,AtomicNum=6)
+    NH=_CalculateAtomEState(mol,AtomicNum=1)
+    
+    return round(Ntotal-NC-NH,3)
+
+
+def CalculateAverageEState(mol):
+    """
+    #################################################################
+    The sum of the EState indices over all non-hydrogen atoms 
+    
+    divided by the number of non-hydrogen atoms.
+    
+    -->Save
+    #################################################################
+    """
+    N=mol.GetNumAtoms()
+    return round(sum(_CalculateEState(mol))/N,3)
+
+def CalculateMaxEState(mol):
+
+    """
+    #################################################################
+    Obtain the maximal Estate value in all atoms
+    
+    -->Smax
+    #################################################################
+    """
+    return round(max(_CalculateEState(mol)),3)
+
+
+def CalculateMinEState(mol):
+    """
+    #################################################################
+    Obtain the minimal Estate value in all atoms
+    
+    -->Smin
+    #################################################################
+    """
+    
+    return round(min(_CalculateEState(mol)),3)
+
+
+def CalculateDiffMaxMinEState(mol):
+    """
+    #################################################################
+    The difference between Smax and Smin
+    
+    -->DS
+    #################################################################
+    """
+    return round(max(_CalculateEState(mol))-min(_CalculateEState(mol)),3)
+    
 
 def CalculateMinAtomTypeEState(mol):
     """
@@ -225,6 +353,15 @@ def GetEstate(mol):
     result.update(CalculateEstateValue(mol))
     result.update(CalculateMaxAtomTypeEState(mol))
     result.update(CalculateMinAtomTypeEState(mol))
+    
+    result.update({'Shev':CalculateHeavyAtomEState(mol)})
+    result.update({'Scar':CalculateCAtomEState(mol)})
+    result.update({'Shal':CalculateHalogenEState(mol)})
+    result.update({'Shet':CalculateHeteroEState(mol)})
+    result.update({'Save':CalculateAverageEState(mol)})
+    result.update({'Smax':CalculateMaxEState(mol)})
+    result.update({'Smin':CalculateMinEState(mol)})
+    result.update({'DS':CalculateDiffMaxMinEState(mol)})
 
     return result
 
@@ -247,6 +384,15 @@ def _GetEstate(mol):
     result.update(CalculateEstateValue(mol))
     result.update(CalculateMaxAtomTypeEState(mol))
     result.update(CalculateMinAtomTypeEState(mol))
+    
+    result.update({'Shev':CalculateHeavyAtomEState(mol)})
+    result.update({'Scar':CalculateCAtomEState(mol)})
+    result.update({'Shal':CalculateHalogenEState(mol)})
+    result.update({'Shet':CalculateHeteroEState(mol)})
+    result.update({'Save':CalculateAverageEState(mol)})
+    result.update({'Smax':CalculateMaxEState(mol)})
+    result.update({'Smin':CalculateMinEState(mol)})
+    result.update({'DS':CalculateDiffMaxMinEState(mol)})
 
     return result
 

--- a/PyBioMed/PyMolecule/kappa.py
+++ b/PyBioMed/PyMolecule/kappa.py
@@ -29,14 +29,14 @@ Email: gadsby@163.com and oriental-cds@163.com
 from rdkit import Chem
 from rdkit.Chem import rdchem
 
-try:
+''' try:
     # TODO: Is this deprecated?
     # https://github.com/rdkit/rdkit/issues/2741#issuecomment-546709239
-    from rdkit.Chem import pyPeriodicTable as PeriodicTable
+    from rdkit.Chem import pyperiodicTable as periodicTable
 except ImportError:
-    from rdkit.Chem import PeriodicTable
+    from rdkit.Chem import periodicTable '''
 
-periodicTable = rdchem.GetPeriodicTable()
+periodicTable = Chem.GetPeriodicTable()
 
 
 Version = 1.0
@@ -135,13 +135,13 @@ def _HallKierAlpha(mol):
     #################################################################
     """
     alphaSum = 0.0
-    rC = PeriodicTable.nameTable["C"][5]
+    rC = periodicTable.GetRb0(6)
     for atom in mol.GetAtoms():
         atNum = atom.GetAtomicNum()
         if not atNum:
             continue
         symb = atom.GetSymbol()
-        alphaV = PeriodicTable.hallKierAlphas.get(symb, None)
+        alphaV = Chem.GraphDescriptors.hallKierAlphas.get(symb, None)
         if alphaV is not None:
             hyb = atom.GetHybridization() - 2
             if hyb < len(alphaV):
@@ -151,7 +151,7 @@ def _HallKierAlpha(mol):
             else:
                 alpha = alphaV[-1]
         else:
-            rA = PeriodicTable.nameTable[symb][5]
+            rA = periodicTable.GetRb0(atNum)
             alpha = rA / rC - 1
         alphaSum += alpha
     return alphaSum

--- a/PyBioMed/PyMolecule/moe.py
+++ b/PyBioMed/PyMolecule/moe.py
@@ -72,6 +72,7 @@ def CalculateTPSA(mol):
     res = {}
     temp = MOE.TPSA(mol)
     res["MTPSA"] = round(temp, 3)
+    res['TPSA1']=round(temp,3)
     return res
 
 

--- a/PyBioMed/PyMolecule/molproperty.py
+++ b/PyBioMed/PyMolecule/molproperty.py
@@ -49,7 +49,7 @@ def CalculateMolLogP(mol):
         Output: result is a numeric value.
     #################################################################
     """
-    return round(Crippen._pyMolLogP(mol), 3)
+    return round(Crippen.MolLogP(mol), 3)
 
 
 def CalculateMolLogP2(mol):
@@ -68,7 +68,7 @@ def CalculateMolLogP2(mol):
         Output: result is a numeric value.
     #################################################################
     """
-    res = Crippen._pyMolLogP(mol)
+    res = Crippen.MolLogP(mol)
 
     return round(res ** 2, 3)
 
@@ -89,7 +89,7 @@ def CalculateMolMR(mol):
         Output: result is a numeric value.
     #################################################################
     """
-    return round(Crippen._pyMolMR(mol), 3)
+    return round(Crippen.MolMR(mol), 3)
 
 
 def CalculateTPSA(mol):


### PR DESCRIPTION
1. While calculating all descriptors I encountered errors in kappa.py as mention in #11. Used the fix in there.

2. I also encountered bugs in molproperty.py which was caused due to `Crippen._pyMolLogP(mol)` & `Crippen._pyMolMR(mol)` and is corrected using `Crippen.MolLogP(mol)` & `Crippen.MolMR(mol)` respectively

3. Also, I added all the remaining descriptors in [Chemopy](https://github.com/salotz/chemopy) for completion purposes and ensuring compatibility with python3 and rdkit==2019.03.1
